### PR TITLE
Exclude tests from packaged distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         ]
     },
     python_requires=">=3.7",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests", "tests.*")),
     include_package_data=True,
     url="https://github.com/brainglobe/imio",
     author="Charly Rousseau, Adam Tyson",


### PR DESCRIPTION
A top-level `tests` package is usually a bad idea since it can be clobbered with other (mispackaged) distributions. If you want to distribute tests, they should be included within the main namespace of the package.

I am patching this as part of the review for the [conda-forge submission](https://github.com/conda-forge/staged-recipes/pull/17820).

Thanks!