### PR TITLE
Add all-contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
     https://github.com/brainglobe/imio/actions)
 [![codecov](https://codecov.io/gh/brainglobe/imio/branch/master/graph/badge.svg?token=M1BXRDJ9V4)](https://codecov.io/gh/brainglobe/imio)[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![Contributions](https://img.shields.io/badge/Contributions-Welcome-brightgreen.svg)](https://github.com/brainglobe/imio)
-
+[![All Contributors](https://img.shields.
+io/github/all-contributors/brainglobe/imio?color=ee8449&style=flat-square)](#contributors)
 
 # imio
 Loading and saving of image data.
@@ -40,3 +41,14 @@ pip install imio
 
 ## Contributing
 Contributions to imio are more than welcome. Please see the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).
+
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
     https://github.com/brainglobe/imio/actions)
 [![codecov](https://codecov.io/gh/brainglobe/imio/branch/master/graph/badge.svg?token=M1BXRDJ9V4)](https://codecov.io/gh/brainglobe/imio)[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![Contributions](https://img.shields.io/badge/Contributions-Welcome-brightgreen.svg)](https://github.com/brainglobe/imio)
-[![All Contributors](https://img.shields.
-io/github/all-contributors/brainglobe/imio?color=ee8449&style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/github/all-contributors/brainglobe/imio?color=ee8449&style=flat-square)](#contributors)
 
 # imio
 Loading and saving of image data.


### PR DESCRIPTION
Adding the minimal tooling to use the [all contributors bot](https://allcontributors.org/docs/en/bot/overview). Once this is merged, we can ask it to add contributors automatically.

Started on this repo as it has a relatively low number of contributors, but eventually this should be:
a) rolled out to all BG repos
b) collated somehow on the website