### PR TITLE
Mark package for deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# This package has moved!
+
+`imio` has been merged into [`brainglobe-utils`](https://github.com/brainglobe/brainglobe-utils) and will no longer be provided standalone.
+If you want to continue using this package's functionality, we recommend you install `brainglobe-utils` and the corresponding submodule.
+
+---
+
 [![Python Version](https://img.shields.io/pypi/pyversions/imio.svg)](https://pypi.org/project/imio)
 [![PyPI](https://img.shields.io/pypi/v/imio.svg)](https://pypi.org/project/imio)
 [![Downloads](https://pepy.tech/badge/imio)](https://pepy.tech/project/imio)

--- a/imio/__init__.py
+++ b/imio/__init__.py
@@ -1,3 +1,12 @@
+from warnings import warn
+
+warn(
+    "imio has merged into brainglobe-utils as a submodule."
+    "To remain up to date, please install brainglobe-utils and use the image_io submodule:"
+    "https://github.com/brainglobe/brainglobe-utils",
+    DeprecationWarning,
+)
+
 __author__ = "Charly Rousseau, Adam Tyson"
 __version__ = "0.2.4"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,5 @@ python =
 extras =
     dev
 commands =
-    pytest -v --color=yes --cov=imio --cov-report=xml
-
+    pytest -v --color=yes --cov=imio --cov-report=xml -W ignore::DeprecationWarning
 """


### PR DESCRIPTION
As per https://github.com/brainglobe/BrainGlobe/issues/64, marks `imio` for deprecation.

Once merged, we should trigger a new release to PyPI.